### PR TITLE
Use system colours for text background

### DIFF
--- a/win/cocoa/MainWindowController.m
+++ b/win/cocoa/MainWindowController.m
@@ -185,6 +185,9 @@ static MainWindowController* instance;
 		// set table row spacing to zero in messages window
 		[messagesView setIntercellSpacing:NSMakeSize(0,0)];
 		
+		// use system colors for dark mode compatibility
+		[messagesView setBackgroundColor:NSColor.textBackgroundColor];
+		
 		// initialize speech engine
 		voice = [[NSSpeechSynthesizer alloc] initWithVoice:@"com.apple.speech.synthesis.voice.Alex"];
 		float r = [voice rate];

--- a/win/cocoa/MenuWindowController.m
+++ b/win/cocoa/MenuWindowController.m
@@ -730,7 +730,7 @@ static BUC_ENUM GetBUC( NSString * text )
 			BUC_ENUM buc = GetBUC( title );
 			if ( buc != BUC_UNCURSED )
 				[aString addAttribute:NSForegroundColorAttributeName
-								value:(buc == BUC_ENUM_BLESSED ? [NSColor blueColor] : [NSColor redColor])
+								value:(buc == BUC_ENUM_BLESSED ? [NSColor systemBlueColor] : [NSColor systemRedColor])
 								range:NSMakeRange(0,[[aString mutableString] length])];
 #endif
 			// adjust baseline of text so it is vertically centered with tile

--- a/win/cocoa/TooltipWindow.m
+++ b/win/cocoa/TooltipWindow.m
@@ -30,11 +30,10 @@
 -(id)initWithText:(NSString *)text location:(NSPoint)point
 {
 	NSTextField * view = [[NSTextField alloc] initWithFrame:NSMakeRect(point.x, point.y, 10, 10)];
-	NSColor * bgColor = [NSColor colorWithDeviceRed:1.0 green:1.0 blue:202/255.0 alpha:1.0];
 	
 	[view setStringValue:text];
 	[view setBordered:YES];
-	[view setBackgroundColor:bgColor];
+	[view setBackgroundColor:NSColor.textBackgroundColor];
 	[view setEditable:NO];
 	[view setSelectable:NO];
 	[view sizeToFit];

--- a/win/cocoa/en.lproj/MainMenu.xib
+++ b/win/cocoa/en.lproj/MainMenu.xib
@@ -2000,7 +2000,7 @@ Gw
                                     <rect key="frame" x="0.0" y="0.0" width="98" height="171"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
                                         <tableColumn identifier="race" editable="NO" width="95" minWidth="40" maxWidth="1000" id="1139">
@@ -2051,7 +2051,7 @@ Gw
                                     <rect key="frame" x="0.0" y="0.0" width="148" height="344"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
                                         <tableColumn identifier="role" editable="NO" width="145" minWidth="40" maxWidth="1000" id="1148">

--- a/win/cocoa/iHack/NhWindow.m
+++ b/win/cocoa/iHack/NhWindow.m
@@ -209,7 +209,7 @@ static NhWindow *s_mapWindow = nil;
 					BOOL highlight = [self stringReferencesHero:s];
 					if ( highlight ) {
 						dict = [NSDictionary dictionaryWithObjectsAndKeys:
-								[NSColor blueColor], NSForegroundColorAttributeName,
+								[NSColor systemBlueColor], NSForegroundColorAttributeName,
 								nil];
 					}
 					BOOL isVoiced = [self stringIsVoiced:s];
@@ -231,8 +231,8 @@ static NhWindow *s_mapWindow = nil;
 			case ATR_BLINK:
 			case ATR_INVERSE:
 				dict = [NSDictionary dictionaryWithObjectsAndKeys:
-						[NSColor redColor], NSForegroundColorAttributeName,
-						[NSColor blueColor], NSBackgroundColorAttributeName,
+						[NSColor systemRedColor], NSForegroundColorAttributeName,
+						[NSColor systemBlueColor], NSBackgroundColorAttributeName,
 						nil];
 				break;
 		}


### PR DESCRIPTION
Ok, I had a go at fixing the dark mode problem mentioned in #28.

The character creation screen, the message log, and tooltips now use standard system colours for their backgrounds, so will switch colour when the system light/dark mode changes.

I also changed the blue text from `NSColor.blueColor` (hard to read against a dark background) to `NSColor.systemBlueColor`. The new blue looks like this:

<img width="569" alt="Screenshot 2021-08-11 at 16 12 44" src="https://user-images.githubusercontent.com/4312404/128979307-0c395df4-e230-4a2d-acda-e97f487ae612.png">
<img width="569" alt="Screenshot 2021-08-11 at 16 12 59" src="https://user-images.githubusercontent.com/4312404/128979330-12bbbd1c-10e1-4ed7-936f-2f86de2c0921.png">

I haven't touched the [ASCII colour palette](https://github.com/bryceco/nethack-cocoa/blob/master/win/cocoa/MainView.m#L128-L145).

Give it a try and see what you think. Let me know if I missed anything.