### PR TITLE
fix config.h file not found

### DIFF
--- a/win/cocoa/bootstrap.sh
+++ b/win/cocoa/bootstrap.sh
@@ -11,7 +11,7 @@
 pushd ../../sys/unix
 
 # no symbolic links used to enable easier patching
-sh setup.sh
+sh setup.sh hints/unix
 
 cd ../..
 


### PR DESCRIPTION
## Issue
Run `sh bootstrap.sh` in `win/coca` before building, get config.h file not found.

## Fix
Change line 14 in `bootstrap.sh` from
```
sh setup.sh
```
to 
```
sh setup.sh hints/unix
```

## Log

Output from running `sh bootstrap.sh`
```
~/Codes/GitHub/nethack-cocoa/sys/unix ~/Codes/GitHub/nethack-cocoa/win/cocoa
rm -f *.o
rm -f lev_lex.c lev_yacc.c dgn_lex.c dgn_yacc.c
rm -f ../include/lev_comp.h ../include/dgn_comp.h
rm -f ../include/tile.h tiletxt.c
rm -f makedefs lev_comp dgn_comp recover dlb
rm -f gif2txt txt2ppm tile2x11 tile2img.ttp xpm2img.ttp \
		tilemap tileedit tile2bmp
cc    -c -o makedefs.o makedefs.c
makedefs.c:10:10: fatal error: 'config.h' file not found
#include "config.h"
         ^~~~~~~~~~
1 error generated.
make: *** [makedefs.o] Error 1
bootstrap.sh: line 19: cd: src: No such file or directory
bootstrap.sh: line 20: ../util/makedefs: No such file or directory
bootstrap.sh: line 21: ../util/makedefs: No such file or directory
bootstrap.sh: line 22: ../util/makedefs: No such file or directory
bootstrap.sh: line 23: ../util/makedefs: No such file or directory
bootstrap.sh: line 24: ../util/makedefs: No such file or directory
rm -f gitinfo.txt
rm -f spec_levs quest_levs *.lev bogusmon data engrave epitaph rumors quest.dat oracles options dungeon dungeon.pdf
rm -f nhdat x11tiles beostiles pet_mark.xbm pilemark.xbm rip.xpm mapbg.xpm
rm -f rip.img GEM_RSC.RSC title.img nh16.img NetHack.ad
rm -f nhsplash.xpm nhtiles.bmp
(cd ../util ; /Applications/Xcode.app/Contents/Developer/usr/bin/make makedefs)
cc    -c -o makedefs.o makedefs.c
makedefs.c:10:10: fatal error: 'config.h' file not found
#include "config.h"
         ^~~~~~~~~~
1 error generated.
make[1]: *** [makedefs.o] Error 1
make: *** [../util/makedefs] Error 2
cc  -c monst.c
monst.c:6:10: fatal error: 'config.h' file not found
#include "config.h"
         ^~~~~~~~~~
1 error generated.
make: *** [monst.o] Error 1
~/Codes/GitHub/nethack-cocoa/win/cocoa
```